### PR TITLE
Allow hiera key local_users::add::users to be an array of hashes.

### DIFF
--- a/manifests/add.pp
+++ b/manifests/add.pp
@@ -37,7 +37,7 @@ class local_users::add (
   $users_keys = lookup( 'local_users::add::keys', Collection, 'unique', [] )
 
   $users = $users_lookup ? {
-    Array   => merge(*flatten($users_lookup)),
+    Array   => merge({}, {}, *flatten($users_lookup)),
     default => $users_lookup
   }
 

--- a/manifests/add.pp
+++ b/manifests/add.pp
@@ -33,8 +33,13 @@ class local_users::add (
   }
 
   # Then perform actions on users
-  $users = lookup( 'local_users::add::users', Data, 'deep', {} )
+  $users_lookup = lookup( 'local_users::add::users', Data, 'deep', {} )
   $users_keys = lookup( 'local_users::add::keys', Collection, 'unique', [] )
+
+  $users = $users_lookup ? {
+    Array   => merge(*flatten($users_lookup)),
+    default => $users_lookup
+  }
 
   $users.each | $name, $props | {
     #notify { "Checking user: $user ($props)": }

--- a/manifests/add.pp
+++ b/manifests/add.pp
@@ -26,7 +26,11 @@ class local_users::add (
   }
 
   # Do group actions first
-  $groups = lookup( 'local_users::add::groups', Data, 'deep', {} )
+  $groups_lookup = lookup( 'local_users::add::groups', Data, 'deep', {} )
+  $groups = $groups_lookup ? {
+    Array   => merge({}, {}, *flatten($groups_lookup)),
+    default => $groups_lookup
+  }
 
   $groups.each | $group, $props | {
     create_resources( group, { $group => $props }, $grp_defaults )

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,9 @@
   "source": "https://github.com/Q-Technologies/puppet-local_users.git",
   "project_page": "https://github.com/Q-Technologies/puppet-local_users",
   "issues_url": "https://github.com/Q-Technologies/puppet-local_users/issues",
-  "dependencies": [],
+  "dependencies": [
+    {"name":"puppetlabs/stdlib", "version_requirement": ">= 2.2.1 < 5.0.0"}
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem":"AIX",


### PR DESCRIPTION
This makes it more practical to assemble logical groups of users as hiera arrays, and assign those groups to local_users::add::users via the hiera %{alias()} lookup function.

For example, I'm using this with the following hiera data:

user_database.yaml:
```yaml
local_users::staff:
  mbaynton:
    uid: 100
    gid: 13779
    comment: Mike Baynton
  user2:
    uid: 1234
    gid: 13779
    comment: Another user
  thirdUser:
    uid: 4567
    gid: 13779
    comment: A third user

local_users::department::developers:
  mbaynton: '%{alias("local_users::staff.mbaynton")}'
  user2: '%{alias("local_users::staff.user2")}'
local_users::department::sysadmins:
  thirdUser: '%{alias("local_users::staff.thirdUser")}'
```

webserver_role.yaml:
```yaml
local_users::add::users:
  - '%{alias("local_users::department::developers")}'
  - '%{alias("local_users::department::sysadmins")}'
```

Would be happy to include mention of this sort of thing in the docs if you're not opposed to the code change.

puppetlabs/stdlib required for the `flatten()` and `merge()` functions.