### PR TITLE
Globally convert local_users::add::users and local_users::add::groups to hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /convert_report.txt
 /update_report.txt
 .DS_Store
+.project
+.envrc
+/inventory.yaml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,32 +10,35 @@ cache:
 before_script:
   - bundle -v
   - rm Gemfile.lock || true
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# Set `rubygems_version` in the .sync.yml to set a value"
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
   - bundle install --without system_tests --path vendor/bundle --jobs $(nproc)
 
-syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.1-Puppet ~> 6.0:
+syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop-Ruby 2.5.7-Puppet ~> 6:
   stage: syntax
-  image: ruby:2.5.1
+  image: ruby:2.5.7
   script:
     - bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop
   variables:
-    PUPPET_GEM_VERSION: '~> 6.0'
+    PUPPET_GEM_VERSION: '~> 6'
 
-parallel_spec-Ruby 2.5.1-Puppet ~> 6.0:
+parallel_spec-Ruby 2.5.7-Puppet ~> 6:
   stage: unit
-  image: ruby:2.5.1
+  image: ruby:2.5.7
   script:
     - bundle exec rake parallel_spec
   variables:
-    PUPPET_GEM_VERSION: '~> 6.0'
+    PUPPET_GEM_VERSION: '~> 6'
 
-parallel_spec-Ruby 2.4.4-Puppet ~> 5.0:
+parallel_spec-Ruby 2.4.5-Puppet ~> 5:
   stage: unit
-  image: ruby:2.4.4
+  image: ruby:2.4.5
   script:
     - bundle exec rake parallel_spec
   variables:
-    PUPPET_GEM_VERSION: '~> 5.0'
+    PUPPET_GEM_VERSION: '~> 5'
 

--- a/.pdkignore
+++ b/.pdkignore
@@ -22,6 +22,9 @@
 /convert_report.txt
 /update_report.txt
 .DS_Store
+.project
+.envrc
+/inventory.yaml
 /appveyor.yml
 /.fixtures.yml
 /Gemfile
@@ -30,8 +33,10 @@
 /.gitlab-ci.yml
 /.pdkignore
 /Rakefile
+/rakelib/
 /.rspec
 /.rubocop.yml
 /.travis.yml
 /.yardopts
 /spec/
+/.vscode/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
-require: rubocop-rspec
+require:
+- rubocop-rspec
+- rubocop-i18n
 AllCops:
   DisplayCopNames: true
   TargetRubyVersion: '2.1'
@@ -19,10 +21,13 @@ AllCops:
 Metrics/LineLength:
   Description: People have wide screens, use them.
   Max: 200
+GetText:
+  Enabled: false
 GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
-  - spec/*
+  - spec/**/*
+  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -35,6 +40,10 @@ Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
+Style/BracesAroundHashParameters:
+  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
+    See https://github.com/rubocop-hq/rubocop/pull/7643
+  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -84,6 +93,12 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
+GetText/DecorateFunctionMessage:
+  Enabled: false
+GetText/DecorateStringFormattingUsingInterpolation:
+  Enabled: false
+GetText/DecorateStringFormattingUsingPercent:
+  Enabled: false
 Layout/EndOfLine:
   Enabled: false
 Layout/IndentHeredoc:

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,0 +1,4 @@
+spec/spec_helper.rb:
+  hiera_config: spec/fixtures/hiera/hiera.yaml
+  spec_overrides: |-
+    add_custom_fact :user_group, { 'root' => 'wheel' }, :confine => 'aix-7100-IBM,8284-22A'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,49 @@
 ---
-dist: trusty
+os: linux
+dist: xenial
 language: ruby
 cache: bundler
 before_install:
   - bundle -v
   - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
+  - "# Update system gems if requested. This is useful to temporarily workaround troubles in the test runner"
+  - "# See https://github.com/puppetlabs/pdk-templates/commit/705154d5c437796b821691b707156e1b056d244f for an example of how this was used"
+  - "# Ignore exit code of SIGPIPE'd yes to not fail with shell's pipefail set"
+  - '[ -z "$RUBYGEMS_VERSION" ] || (yes || true) | gem update --system $RUBYGEMS_VERSION'
   - gem --version
   - bundle -v
 script:
   - 'bundle exec rake $CHECK'
 bundler_args: --without system_tests
 rvm:
-  - 2.5.1
-env:
-  global:
-    - BEAKER_PUPPET_COLLECTION=puppet6 PUPPET_GEM_VERSION="~> 6.0"
-matrix:
+  - 2.5.7
+stages:
+  - static
+  - spec
+  - acceptance
+  -
+    if: tag =~ ^v\d
+    name: deploy
+jobs:
   fast_finish: true
   include:
     -
-      env: CHECK="syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop"
-    -
-      env: CHECK=parallel_spec
+      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
+      stage: static
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.4
+      rvm: 2.4.5
+      stage: spec
+    -
+      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+      rvm: 2.5.7
+      stage: spec
+    -
+      env: DEPLOY_TO_FORGE=yes
+      stage: deploy
 branches:
   only:
     - master
     - /^v\d/
 notifications:
   email: false
-deploy:
-  provider: puppetforge
-  user: puppet
-  password:
-    secure: ""
-  on:
-    tags: true
-    all_branches: true
-    condition: "$DEPLOY_TO_FORGE = yes"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "puppet.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/Gemfile
+++ b/Gemfile
@@ -17,16 +17,17 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "fast_gettext", '1.1.0',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                  require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                         require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                               require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                               require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                               require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}",     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}",   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}",       require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
+  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
+  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
+  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
+  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
+  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
+  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,6 @@
+# frozen_string_literal: true
+
+require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
@@ -14,15 +17,24 @@ end
 
 def changelog_project
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = nil || JSON.load(File.read('metadata.json'))['name']
-  raise "unable to find the changelog_project in .sync.yml or the name in metadata.json" if returnVal.nil?
+
+  returnVal = nil
+  returnVal ||= begin
+    metadata_source = JSON.load(File.read('metadata.json'))['source']
+    metadata_source_match = metadata_source && metadata_source.match(%r{.*\/([^\/]*?)(?:\.git)?\Z})
+
+    metadata_source_match && metadata_source_match[1]
+  end
+
+  raise "unable to find the changelog_project in .sync.yml or calculate it from the source in metadata.json" if returnVal.nil?
+
   puts "GitHubChangelogGenerator project:#{returnVal}"
   returnVal
 end
 
 def changelog_future_release
   return unless Rake.application.top_level_tasks.include? "changelog"
-  returnVal = JSON.load(File.read('metadata.json'))['version']
+  returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
   raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
   puts "GitHubChangelogGenerator future_release:#{returnVal}"
   returnVal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ version: 1.1.x.{build}
 branches:
   only:
     - master
+    - release
 skip_commits:
   message: /^\(?doc\)?.*/
 clone_depth: 10

--- a/manifests/add.pp
+++ b/manifests/add.pp
@@ -34,13 +34,7 @@ class local_users::add (
   }
 
   # Do group actions first
-  $groups_lookup = $local_users::groups_to_add
-  $groups = $groups_lookup ? {
-    Array   => merge({}, {}, *flatten($groups_lookup)),
-    default => $groups_lookup
-  }
-
-  $groups.each | $group, $props | {
+  $local_users::groups_to_add.each | $group, $props | {
     create_resources( group, { $group => $props }, $grp_defaults )
   }
 
@@ -48,16 +42,9 @@ class local_users::add (
   if $facts['osfamily'] == 'AIX' {
         $users_pgrp = $facts['user_group']
   }
+
   # Then perform actions on users
-  $users_lookup = $local_users::users_to_add
-  $users_keys = $local_users::users_keys
-
-  $users = $users_lookup ? {
-    Array   => merge({}, {}, *flatten($users_lookup)),
-    default => $users_lookup
-  }
-
-  $users.each | $name, $props | {
+  $local_users::users_to_add.each | $name, $props | {
     #notify { "Checking user: $user ($props)": }
 
     if $props[generate] {
@@ -360,7 +347,7 @@ class local_users::add (
             if $keys =~ Array {
               $keys.each | $key | {
                 #notify { "Checking authorized keys for $user: $key": }
-                $users_keys.each | $user_key | {
+                $local_users::users_keys.each | $user_key | {
                   $comment = $user_key[comment]
                   #notify { "Checking authorized keys for $user: $key ($comment)": }
                   if $comment == $key {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,10 +7,22 @@ class local_users(
   $users_to_remove = lookup('local_users::remove::users', Collection, 'unique', [])
   $sysusers_to_remove = lookup('local_users::remove::sysusers', Collection, 'unique', [])
   $groups_to_remove = lookup('local_users::remove::groups', Collection, 'unique', [])
+
   $users_to_ignore = lookup('local_users::ignore::users', Collection, 'unique', [])
   $groups_to_ignore = lookup('local_users::ignore::groups', Collection, 'unique', [])
-  $users_to_add = lookup( 'local_users::add::users', Data, 'deep', {} )
-  $groups_to_add = lookup( 'local_users::add::groups', Data, 'deep', {} )
+
+  $users_lookup = lookup( 'local_users::add::users', Data, 'deep', {} )
+  $users_to_add = $users_lookup ? {
+    Array   => merge({}, {}, *flatten($users_lookup)),
+    default => $users_lookup
+  }
+
+  $groups_lookup = lookup( 'local_users::add::groups', Data, 'deep', {} )
+  $groups_to_add = $groups_lookup ? {
+    Array   => merge({}, {}, *flatten($groups_lookup)),
+    default => $groups_lookup
+  }
+
   $users_keys = lookup( 'local_users::add::keys', Collection, 'unique', [] )
 
   class { 'local_users::remove': }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,5 @@
 {
   "name": "qtechnologies-local_users",
-
   "version": "1.4.1",
   "author": "Q-Technologies",
   "summary": "Puppet module to easily manage local users and their authorized keys",
@@ -32,8 +31,8 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6.0",
-        "7.0"
+        "6",
+        "7"
       ]
     },
     {
@@ -57,7 +56,7 @@
     "ssh_keys",
     "sshkeys"
   ],
-  "pdk-version": "1.9.1",
-  "template-url": "file:///opt/puppetlabs/pdk/share/cache/pdk-templates.git",
-  "template-ref": "1.9.1-0-g6945d31"
+  "pdk-version": "1.18.0",
+  "template-url": "pdk-default#1.18.0",
+  "template-ref": "tags/1.18.0-0-g095317c"
 }

--- a/spec/classes/local_users_spec.rb
+++ b/spec/classes/local_users_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'local_users::add' do
+describe 'local_users' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -3,5 +3,6 @@
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
 ipaddress: "172.16.254.254"
+ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
 is_pe: false
 macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
Specifying `local_users::add::users` as an array would cause a compilation failure in `local_users::remove` as the conversation to a hash was only occurring in `local_users::add`. This moves that conversion into the base class to fix the failure. The PDK template was also updated and the spec tests were fixed to work on RHEL and AIX.